### PR TITLE
Dont allow save of 'empty' WLAN Client or AP SSID/Password from GUI

### DIFF
--- a/main/src/web_server.c
+++ b/main/src/web_server.c
@@ -566,13 +566,16 @@ static esp_err_t wifi_credentials_handler(httpd_req_t *req)
     ESP_LOGI(TAG, "query string len: %d => %s", len, content);
     ESP_LOGI(TAG, "ssid: %s, pass: %s, type: %s, auth: %d", _ssid, _pass, type?"AP":"STA", _auth);
 
-    if (type)
+    if (ssid_len && pass_len)
     {
-        wifi_init_softap(_ssid, _pass, _auth);
-        storeWifiCredsAP(_ssid, _pass);
-    } else {
-        wifi_init_sta(_ssid, _pass);
-        storeWifiCredsSTA(_ssid, _pass);
+        if (type) 
+        {
+            wifi_init_softap(_ssid, _pass, _auth);
+            storeWifiCredsAP(_ssid, _pass);
+        } else {
+            wifi_init_sta(_ssid, _pass);
+            storeWifiCredsSTA(_ssid, _pass);
+        }
     }
 
     /* Respond with an empty chunk to signal HTTP response completion */

--- a/main/src/web_server.c
+++ b/main/src/web_server.c
@@ -566,7 +566,7 @@ static esp_err_t wifi_credentials_handler(httpd_req_t *req)
     ESP_LOGI(TAG, "query string len: %d => %s", len, content);
     ESP_LOGI(TAG, "ssid: %s, pass: %s, type: %s, auth: %d", _ssid, _pass, type?"AP":"STA", _auth);
 
-    if (ssid_len && pass_len)
+    if (ssid_len && (!pass_len || ( 8 <= pass_len && pass_len <= 32 )))
     {
         if (type) 
         {

--- a/main/src/wifi.c
+++ b/main/src/wifi.c
@@ -115,6 +115,7 @@ void wifi_init_sta(char* ssid, char* pass)
     strcpy((char*)wifi_config.sta.password, pass);
 
     ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
+    esp_wifi_disconnect(); // if we're trying to connect with wrong credentials, don't bomb.
     ESP_ERROR_CHECK( esp_wifi_connect() );
 
     ESP_LOGI(TAG, "wifi_init_sta finished. SSID:%s password:%s",


### PR DESCRIPTION
- Don't save empty user/password strings from users simply clicking 'commit'.
- Don't bomb if you set new credentials while connecton is in progress.